### PR TITLE
Fix examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ This package supports discovering, connecting and controlling Yeelight Devices.
         device.sendCommand({
             id: -1,
             method: 'set_power',
-            params: [true, 'smooth', '300']
+            params: ["on", 'smooth', 300]
         })
     })    
 

--- a/examples/device.js
+++ b/examples/device.js
@@ -14,7 +14,7 @@ device.on('connected', () => {
     device.sendCommand({
         id: -1,
         method: 'set_power',
-        params: [true, 'smooth', '300']
+        params: ["on", 'smooth', 300]
     })
 })    
 // device.disconnect()


### PR DESCRIPTION
Sending the duration as string fails to start/stop the lights.

To turn on/off the lights, the data is "on" and "off".