### PR TITLE
Add custom attributes tracking

### DIFF
--- a/src/device.js
+++ b/src/device.js
@@ -17,6 +17,7 @@ class YeeDevice extends EventEmitter {
     this.connected = false
     this.forceDisconnect = false
     this.timer = null
+    this.tracked_attrs = this.device.tracked_attrs || ['power', 'bright', 'rgb', 'flowing', 'flow_params', 'hue', 'sat', 'ct']
     this.polligInterval = this.device.interval || 5000
     this.retry_timer = null
   }
@@ -89,7 +90,7 @@ class YeeDevice extends EventEmitter {
     this.sendCommand({
       id: 199,
       method: 'get_prop',
-      params: ['power', 'bright', 'rgb', 'flowing', 'flow_params', 'hue', 'sat', 'ct'],
+      params: this.tracked_attrs,
     })
   }
 


### PR DESCRIPTION
Track custom attributes:

Allows tracking of background light for the Ceiling light Jiaoyue 650.

We could also add a "track_bg" parameter which would enable the background light tracking.